### PR TITLE
Improve loading screen detection

### DIFF
--- a/TLOU2/tlou2-60fps/tlou2/script.asl
+++ b/TLOU2/tlou2-60fps/tlou2/script.asl
@@ -39,24 +39,34 @@ update
 		// vars.blackness corresponds to a value where the lower the value, the more black the measured areas
 		// This is done using the sum of the squared errors
 		// The value of 94.1176 was found empirically using LiveSplit.
-		// Unsure why features[...].current will go either both up or down when non-black, but this seems to work 
-		vars.blackness =	Math.Pow( features["black1"].current - 94.1176, 2.0) + 
-					Math.Pow( features["black2"].current - 94.1176, 2.0) + 
-					//Math.Pow( features["black3"].current - 94.1176, 2.0) + 
-					Math.Pow( features["black4"].current - 94.1176, 2.0);
+		// Unsure why features[...].current will go either both up or down when non-black, but this seems to work
+
+		var black1 = features["black1"].current;
+		var black2 = features["black2"].current;
+		var black3 = features["black3"].current;
+		var black4 = features["black4"].current;
+
+		vars.blackness = Math.Pow(black1 - 94.1176, 2.0) + 
+				 Math.Pow(black2 - 94.1176, 2.0) + 
+				 Math.Pow(black3 - 94.1176, 2.0) + 
+				 Math.Pow(black4 - 94.1176, 2.0);
 	
 		// Designates when the screen is absolutely black:
 		vars.isBlack  = vars.blackness <= 1.0;
 
+		// Subtract the worst match in case a loading screen moth flies under one of them.
+		var minBlack = Math.Min(black1, Math.Min(black2, Math.Min(black3, black4)));
+		var mothBlackness = vars.blackness - Math.Pow(minBlack - 94.1176, 2.0);
+
 		// The following uses the same blackness value to determine the likelihood that the curent screen is not moths
 		// This is where moth RNG can break the laod remover, perhaps there is better logic or black probe placement 
-		//vars.definitelyNotMoths =  vars.blackness > 1000.0;	// Failed at 1345 from PDub: https://www.twitch.tv/pdub/clip/UgliestInventiveSrirachaM4xHeh
+		//vars.definitelyNotMoths = mothBlackness > 1000.0;	// Failed at 1345 from PDub: https://www.twitch.tv/pdub/clip/UgliestInventiveSrirachaM4xHeh
 								 	// Failed at 1020 from PDub: https://www.twitch.tv/pdub/clip/BrainyAmazingTomatoPeteZarollTie
 									// Per the above 2 failures, moving threshold to 1500.  At final Ellie guitar, value should be at ~2000
-		//vars.definitelyNotMoths =  vars.blackness > 1500.0;	// Failed at 1458 from PDub: https://clips.twitch.tv/CharmingPoisedLocustOhMyDog
+		//vars.definitelyNotMoths = mothBlackness > 1500.0;	// Failed at 1458 from PDub: https://clips.twitch.tv/CharmingPoisedLocustOhMyDog
 									// Per the above, change to 1750.  Also moved black4 left 160 pixels left, further from moths.
 									// Similarly, also moved black1 a bit left and down
-		vars.definitelyNotMoths =  vars.blackness > 1750.0;
+		vars.definitelyNotMoths = mothBlackness > 1750.0;
 
 	}
 

--- a/TLOU2/tlou2-60fps/tlou2/structure.xml
+++ b/TLOU2/tlou2-60fps/tlou2/structure.xml
@@ -202,29 +202,29 @@
               </Watcher>
             </Watches>
         </WatchZone>
-<!--
-          <WatchZone>
-            <Name>black3</Name>
-            <Geometry>
-              <X>200</X>
-              <Y>350</Y>
-              <Width>80</Width>
-              <Height>40</Height>
-            </Geometry>
-            <Watches>
-              <Watcher>
-                <Name>loading</Name>
-              <ErrorMetric>PeakAbsolute</ErrorMetric>
-		<Equalize>false</Equalize>
-                <WatchImages>
-                  <WatchImage>
-                    <FilePath>imgs\black.png</FilePath>
-                  </WatchImage>
-                </WatchImages>
-              </Watcher>
-            </Watches>
+
+        <WatchZone>
+          <Name>black3</Name>
+          <Geometry>
+            <X>1840</X>
+            <Y>1040</Y>
+            <Width>80</Width>
+            <Height>40</Height>
+          </Geometry>
+          <Watches>
+            <Watcher>
+              <Name>loading</Name>
+            <ErrorMetric>PeakAbsolute</ErrorMetric>
+              <Equalize>false</Equalize>
+              <WatchImages>
+                <WatchImage>
+                  <FilePath>imgs\black.png</FilePath>
+                </WatchImage>
+              </WatchImages>
+            </Watcher>
+          </Watches>
         </WatchZone>
--->
+
           <WatchZone>
             <Name>black4</Name>
             <Geometry>


### PR DESCRIPTION
Fixes the case where a moth flies under one of the 3 black rectangles that we sample to detect loading screens. It does this by sampling an extra 4th rectangle and discarding the rectangle with the worst match, since we can probably assume only one random moth will accidentally fly under one of them at a time. If this doesn't end up being true in some cases, we could probably improve it even more by adding a 5th rectangle for extra robustness.

The new `black3.png` rectangle is positioned in the bottom right corner, which is a very bright area in the final Ellie guitar scene. But LMK if this conflicts with any other areas that you know of...

Also I didn't recreate the `.vas` file in this PR... but I could do it if you want (I figured you might want to test it first or something).