### PR TITLE
Adjust skip/restart png offset

### DIFF
--- a/TLOU2/tlou2-60fps/tlou2/structure.xml
+++ b/TLOU2/tlou2-60fps/tlou2/structure.xml
@@ -14,7 +14,7 @@
             <Name>SkipCinematic</Name>
             <Geometry>
               <X>484</X>
-              <Y>420</Y>
+              <Y>421</Y>
               <Width>66</Width>
               <Height>24</Height>
             </Geometry>
@@ -35,7 +35,7 @@
             <Name>Restart</Name>
             <Geometry>
               <X>484</X>
-              <Y>420</Y>
+              <Y>421</Y>
               <Width>66</Width>
               <Height>24</Height>
             </Geometry>


### PR DESCRIPTION
Moving them one pixel down increases the image comparison accuracy on my end. 

In Blegas' stream yesterday, the IGT continued to run after a skip cutscene because the `SkipCinematic` feature returned a value of `9.8` when it needed to be at least `15` in order to be detected. This change seems to increase that accuracy from `9.8` to `36`.

Adjusting the `Restart` offset results in a similar improvement. 